### PR TITLE
Don’t modify inputs!

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For a practical example, see the [world map](https://bl.ocks.org/mbostock/418063
 
 <a name="bbox" href="#bbox">#</a> topojson.<b>bbox</b>(<i>topology</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/bbox.js "Source")
 
-Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no non-empty arcs, the returned bounding box is [∞, ∞, -∞, -∞].
+Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no arcs, the returned bounding box is [∞, ∞, -∞, -∞].
 
 <a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>n</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Returns the computed [bounding box](https://github.com/topojson/topojson-specifi
 
 <a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>n</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
 
-Returns a shallow copy of the specified *topology* with quantized and [delta-encoded](https://github.com/topojson/topojson-specification#213-arcs) arcs. The quantization parameter *n* must be a positive integer greater than one, and determines the maximum expressible number of unique values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a [bbox](#bbox), one is computed. If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
+Returns a shallow copy of the specified *topology* with [quantized and delta-encoded](https://github.com/topojson/topojson-specification#213-arcs) arcs. The quantization parameter *n* must be a positive integer greater than one, and determines the maximum expressible number of unique values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a [bbox](#bbox), one is computed. If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
 
 <a name="_transform" href="#_transform">#</a> <i>transform</i>(<i>point</i>[, <i>index</i>])
 

--- a/README.md
+++ b/README.md
@@ -94,31 +94,23 @@ For a practical example, see the [world map](https://bl.ocks.org/mbostock/418063
 
 <a name="bbox" href="#bbox">#</a> topojson.<b>bbox</b>(<i>topology</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/bbox.js "Source")
 
-If the given *topology* has a [*topology*.bbox](https://github.com/topojson/topojson-specification#3-bounding-boxes), returns it. Otherwise, computes the bounding box of the *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. The computed bounding box is then assigned to *topology*.bbox and returned. If the *topology* has no points and no non-empty arcs, the returned bounding box is [∞, ∞, -∞, -∞].
-
-**CAUTION:** The input *topology* is modified **in-place**.
+Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no non-empty arcs, the returned bounding box is [∞, ∞, -∞, -∞].
 
 <a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>n</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
 
-Quantizes the coordinates of the specified *topology* and [delta-encodes](https://github.com/topojson/topojson-specification#213-arcs) the *topology*’s arcs. The quantization parameter *n* must be a positive integer greater than one, and determines the maximum expressible number of unique values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a [bbox](#bbox), one is computed and assigned. If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
-
-**CAUTION:** The input *topology* is modified **in-place**.
+Returns a shallow copy of the specified *topology* with quantized and [delta-encoded](https://github.com/topojson/topojson-specification#213-arcs) arcs. The quantization parameter *n* must be a positive integer greater than one, and determines the maximum expressible number of unique values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a [bbox](#bbox), one is computed. If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
 
 <a name="_transform" href="#_transform">#</a> <i>transform</i>(<i>point</i>[, <i>index</i>])
 
-Transforms the specified *point* **in-place**, modifying the *point*’s coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to the transform, as is the case with delta-encoded arcs. Returns the specified *point*.
+Applies the transform to the specified *point*, returning a new point with the transformed coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to the transform, as is the case with delta-encoded arcs.
 
-<a name="transform" href="#transform">#</a> topojson.<b>transform</b>(<i>topology</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/transform.js "Source")
+<a name="transform" href="#transform">#</a> topojson.<b>transform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/transform.js "Source")
 
-If the specified *topology*’s [transform object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to remove delta-encoding and apply the transform. If the *topology*’s transform object is null, returns the identity function.
+If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to remove delta-encoding and apply the transform. If the *transform* is null, returns the identity function.
 
-**CAUTION:** The input *topology* is modified **in-place**.
+<a name="untransform" href="#untransform">#</a> topojson.<b>untransform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/untransform.js "Source")
 
-<a name="untransform" href="#untransform">#</a> topojson.<b>untransform</b>(<i>topology</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/untransform.js "Source")
-
-If the specified *topology*’s [transform object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply delta-encoding and remove the transform. If the *topology*’s transform object is null, returns the identity function.
-
-**CAUTION:** The input *topology* is modified **in-place**.
+If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply delta-encoding and remove the transform. If the *transform* is null, returns the identity function.
 
 ## Command Line Reference
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If the specified [*transform* object](https://github.com/topojson/topojson-speci
 
 <a name="untransform" href="#untransform">#</a> topojson.<b>untransform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/untransform.js "Source")
 
-If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply delta-encoding and remove the transform. If the *transform* is null, returns the identity function.
+If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply quantized delta-encoding and remove the transform. If the *transform* is null, returns the identity function.
 
 ## Command Line Reference
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,11 @@ For a practical example, see the [world map](https://bl.ocks.org/mbostock/418063
 
 Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no arcs, the returned bounding box is [∞, ∞, -∞, -∞]. (This method ignores the existing *topology*.bbox, if any.)
 
-<a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>n</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
+<a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
 
-Returns a shallow copy of the specified *topology* with [quantized and delta-encoded](https://github.com/topojson/topojson-specification#213-arcs) arcs. The quantization parameter *n* must be a positive integer greater than one, and determines the maximum expressible number of unique values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a [bbox](#bbox), one is computed. If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
+Returns a shallow copy of the specified *topology* with [quantized and delta-encoded](https://github.com/topojson/topojson-specification#213-arcs) arcs according to the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms). If the *topology* is already quantized, an error is thrown. See also [topoquantize](#topoquantize).
 
-<a name="_transform" href="#_transform">#</a> <i>transform</i>(<i>point</i>[, <i>index</i>])
-
-Applies this transform to the specified *point*, returning a new point with the transformed coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to this transform, as is the case with delta-encoded arcs.
+If a quantization number *n* is specified instead of a *transform* object, the corresponding transform object is first computed using the bounding box of the topology. In this case, the quantization number *n* must be a positive integer greater than one which determines the maximum number of expressible values per dimension in the resulting quantized coordinates; typically, a power of ten is chosen such as 1e4, 1e5 or 1e6. If the *topology* does not already have a *topology*.bbox, one is computed using [topojson.bbox](#bbox).
 
 <a name="transform" href="#transform">#</a> topojson.<b>transform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/transform.js "Source")
 
@@ -111,6 +109,10 @@ If the specified [*transform* object](https://github.com/topojson/topojson-speci
 <a name="untransform" href="#untransform">#</a> topojson.<b>untransform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/untransform.js "Source")
 
 If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply quantized delta-encoding and remove the transform. If the *transform* is null, returns the identity function. See also [topojson.quantize](#quantize).
+
+<a name="_transform" href="#_transform">#</a> <i>transform</i>(<i>point</i>[, <i>index</i>])
+
+Applies this transform function to the specified *point*, returning a new point with the transformed coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to this transform, as is the case with delta-encoded arcs.
 
 ## Command Line Reference
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The **topojson-client** module provides tools for manipulating [TopoJSON](https:
 <!DOCTYPE html>
 <canvas width="960" height="600"></canvas>
 <script src="https://d3js.org/d3.v4.min.js"></script>
-<script src="https://d3js.org/topojson.v2.min.js"></script>
+<script src="https://unpkg.com/topojson-client@3"></script>
 <script>
 
 var context = d3.select("canvas").node().getContext("2d"),
@@ -25,10 +25,10 @@ d3.json("https://d3js.org/us-10m.v1.json", function(error, us) {
 
 ## Installing
 
-If you use NPM, `npm install topojson-client`. Otherwise, download the [latest release](https://github.com/topojson/topojson-client/releases/latest). You can also load directly from [UNPKG](https://unpkg.com) as a [standalone library](https://unpkg.com/topojson-client@2). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `topojson` global is exported:
+If you use NPM, `npm install topojson-client`. Otherwise, download the [latest release](https://github.com/topojson/topojson-client/releases/latest). You can also load directly from [UNPKG](https://unpkg.com) as a [standalone library](https://unpkg.com/topojson-client@3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `topojson` global is exported:
 
 ```html
-<script src="https://unpkg.com/topojson-client@2"></script>
+<script src="https://unpkg.com/topojson-client@3"></script>
 <script>
 
 var feature = topojson.feature(topology, topology.objects.foo);

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If the specified [*transform* object](https://github.com/topojson/topojson-speci
 
 <a name="untransform" href="#untransform">#</a> topojson.<b>untransform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/untransform.js "Source")
 
-If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply quantized delta-encoding and remove the transform. If the *transform* is null, returns the identity function.
+If the specified [*transform* object](https://github.com/topojson/topojson-specification/blob/master/README.md#212-transforms) is non-null, returns a [point *transform* function](#_transform) to apply quantized delta-encoding and remove the transform. If the *transform* is null, returns the identity function. See also [topojson.quantize](#quantize).
 
 ## Command Line Reference
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import * as topojson from "topojson-client";
 
 <a name="feature" href="#feature">#</a> topojson.<b>feature</b>(<i>topology</i>, <i>object</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/feature.js "Source")
 
-Returns the GeoJSON Feature or FeatureCollection for the specified *object* in the given *topology*. If the specified object is a GeometryCollection, a FeatureCollection is returned, and each geometry in the collection is mapped to a Feature. Otherwise, a Feature is returned.
+Returns the GeoJSON Feature or FeatureCollection for the specified *object* in the given *topology*. If the specified object is a GeometryCollection, a FeatureCollection is returned, and each geometry in the collection is mapped to a Feature. Otherwise, a Feature is returned. The returned feature is a shallow copy of the source *object*: they may share identifiers, bounding boxes, properties and coordinates.
 
 Some examples:
 
@@ -62,15 +62,15 @@ See [feature-test.js](https://github.com/topojson/topojson-client/blob/master/te
 
 <a name="merge" href="#merge">#</a> topojson.<b>merge</b>(<i>topology</i>, <i>objects</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/merge.js#L5 "Source")
 
-Returns the GeoJSON MultiPolygon geometry object representing the union for the specified array of Polygon and MultiPolygon *objects* in the given *topology*. Interior borders shared by adjacent polygons are removed. See [Merging States](https://bl.ocks.org/mbostock/5416405) for an example.
+Returns the GeoJSON MultiPolygon geometry object representing the union for the specified array of Polygon and MultiPolygon *objects* in the given *topology*. Interior borders shared by adjacent polygons are removed. See [Merging States](https://bl.ocks.org/mbostock/5416405) for an example. The returned geometry is a shallow copy of the source *object*: they may share coordinates.
 
 <a name="mergeArcs" href="#mergeArcs">#</a> topojson.<b>mergeArcs</b>(<i>topology</i>, <i>objects</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/merge.js#L9 "Source")
 
-Equivalent to [topojson.merge](#merge), but returns TopoJSON rather than GeoJSON.
+Equivalent to [topojson.merge](#merge), but returns TopoJSON rather than GeoJSON. The returned geometry is a shallow copy of the source *object*: they may share coordinates.
 
 <a name="mesh" href="#mesh">#</a> topojson.<b>mesh</b>(<i>topology</i>[, <i>object</i>[, <i>filter</i>]]) [<>](https://github.com/topojson/topojson-client/blob/master/src/mesh.js#L4 "Source")
 
-Returns the GeoJSON MultiLineString geometry object representing the mesh for the specified *object* in the given *topology*. This is useful for rendering strokes in complicated objects efficiently, as edges that are shared by multiple features are only stroked once. If *object* is not specified, a mesh of the entire topology is returned.
+Returns the GeoJSON MultiLineString geometry object representing the mesh for the specified *object* in the given *topology*. This is useful for rendering strokes in complicated objects efficiently, as edges that are shared by multiple features are only stroked once. If *object* is not specified, a mesh of the entire topology is returned. The returned geometry is a shallow copy of the source *object*: they may share coordinates.
 
 An optional *filter* function may be specified to prune arcs from the returned mesh using the topology. The filter function is called once for each candidate arc and takes two arguments, *a* and *b*, two geometry objects that share that arc. Each arc is only included in the resulting mesh if the filter function returns true. For typical map topologies the geometries *a* and *b* are adjacent polygons and the candidate arc is their boundary. If an arc is only used by a single geometry then *a* and *b* are identical. This property is useful for separating interior and exterior boundaries; an easy way to produce a mesh of interior boundaries is:
 
@@ -82,7 +82,7 @@ See this [county choropleth](https://bl.ocks.org/mbostock/4060606) for example. 
 
 <a name="meshArcs" href="#meshArcs">#</a> topojson.<b>meshArcs</b>(<i>topology</i>[, <i>object</i>[, <i>filter</i>]]) [<>](https://github.com/topojson/topojson-client/blob/master/src/mesh.js#L8 "Source")
 
-Equivalent to [topojson.mesh](#mesh), but returns TopoJSON rather than GeoJSON.
+Equivalent to [topojson.mesh](#mesh), but returns TopoJSON rather than GeoJSON. The returned geometry is a shallow copy of the source *object*: they may share coordinates.
 
 <a name="neighbors" href="#neighbors">#</a> topojson.<b>neighbors</b>(<i>objects</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/neighbors.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Returns a shallow copy of the specified *topology* with [quantized and delta-enc
 
 <a name="_transform" href="#_transform">#</a> <i>transform</i>(<i>point</i>[, <i>index</i>])
 
-Applies the transform to the specified *point*, returning a new point with the transformed coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to the transform, as is the case with delta-encoded arcs.
+Applies this transform to the specified *point*, returning a new point with the transformed coordinates. If the specified *index* is truthy, the input *point* is treated as relative to the previous point passed to this transform, as is the case with delta-encoded arcs.
 
 <a name="transform" href="#transform">#</a> topojson.<b>transform</b>(<i>transform</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/transform.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For a practical example, see the [world map](https://bl.ocks.org/mbostock/418063
 
 <a name="bbox" href="#bbox">#</a> topojson.<b>bbox</b>(<i>topology</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/bbox.js "Source")
 
-Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no arcs, the returned bounding box is [∞, ∞, -∞, -∞].
+Returns the computed [bounding box](https://github.com/topojson/topojson-specification#3-bounding-boxes) of the specified *topology* [*x*₀, *y*₀, *x*₁, *y*₁] where *x*₀ is the minimum *x*-value, *y*₀ is the minimum *y*-value, *x*₁ is the maximum *x*-value, and *y*₁ is the maximum *y*-value. If the *topology* has no points and no arcs, the returned bounding box is [∞, ∞, -∞, -∞]. (This method ignores the existing *topology*.bbox, if any.)
 
 <a name="quantize" href="#quantize">#</a> topojson.<b>quantize</b>(<i>topology</i>, <i>n</i>) [<>](https://github.com/topojson/topojson-client/blob/master/src/quantize.js "Source")
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "eslint": "3",
     "package-preamble": "0.0",
-    "rollup": "0.36",
+    "rollup": "0.41",
     "tape": "4",
     "uglify-js": "2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topojson-client",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Manipulate TopoJSON and convert it to GeoJSON.",
   "keywords": [
     "topojson",

--- a/src/bbox.js
+++ b/src/bbox.js
@@ -1,45 +1,39 @@
 import transform from "./transform";
 
 export default function(topology) {
-  var bbox = topology.bbox;
+  var t = transform(topology.transform), key,
+      x0 = Infinity, y0 = x0, x1 = -x0, y1 = -x0;
 
-  function bboxPoint(p0) {
-    p1[0] = p0[0], p1[1] = p0[1], t(p1);
-    if (p1[0] < x0) x0 = p1[0];
-    if (p1[0] > x1) x1 = p1[0];
-    if (p1[1] < y0) y0 = p1[1];
-    if (p1[1] > y1) y1 = p1[1];
+  function bboxPoint(p) {
+    p = t(p);
+    if (p[0] < x0) x0 = p[0];
+    if (p[0] > x1) x1 = p[0];
+    if (p[1] < y0) y0 = p[1];
+    if (p[1] > y1) y1 = p[1];
   }
 
-  function bboxGeometry(o) {
+  function bboxPoints(o) {
     switch (o.type) {
-      case "GeometryCollection": o.geometries.forEach(bboxGeometry); break;
+      case "GeometryCollection": o.geometries.forEach(bboxPoints); break;
       case "Point": bboxPoint(o.coordinates); break;
       case "MultiPoint": o.coordinates.forEach(bboxPoint); break;
     }
   }
 
-  if (!bbox) {
-    var t = transform(topology), p0, p1 = new Array(2), name,
-        x0 = Infinity, y0 = x0, x1 = -x0, y1 = -x0;
-
-    topology.arcs.forEach(function(arc) {
-      var i = -1, n = arc.length;
-      while (++i < n) {
-        p0 = arc[i], p1[0] = p0[0], p1[1] = p0[1], t(p1, i);
-        if (p1[0] < x0) x0 = p1[0];
-        if (p1[0] > x1) x1 = p1[0];
-        if (p1[1] < y0) y0 = p1[1];
-        if (p1[1] > y1) y1 = p1[1];
-      }
-    });
-
-    for (name in topology.objects) {
-      bboxGeometry(topology.objects[name]);
+  topology.arcs.forEach(function(arc) {
+    var i = -1, n = arc.length, p;
+    while (++i < n) {
+      p = t(arc[i], i);
+      if (p[0] < x0) x0 = p[0];
+      if (p[0] > x1) x1 = p[0];
+      if (p[1] < y0) y0 = p[1];
+      if (p[1] > y1) y1 = p[1];
     }
+  });
 
-    bbox = topology.bbox = [x0, y0, x1, y1];
+  for (key in topology.objects) {
+    bboxPoints(topology.objects[key]);
   }
 
-  return bbox;
+  return [x0, y0, x1, y1];
 }

--- a/src/bbox.js
+++ b/src/bbox.js
@@ -12,9 +12,9 @@ export default function(topology) {
     if (p[1] > y1) y1 = p[1];
   }
 
-  function bboxPoints(o) {
+  function bboxGeometry(o) {
     switch (o.type) {
-      case "GeometryCollection": o.geometries.forEach(bboxPoints); break;
+      case "GeometryCollection": o.geometries.forEach(bboxGeometry); break;
       case "Point": bboxPoint(o.coordinates); break;
       case "MultiPoint": o.coordinates.forEach(bboxPoint); break;
     }
@@ -32,7 +32,7 @@ export default function(topology) {
   });
 
   for (key in topology.objects) {
-    bboxPoints(topology.objects[key]);
+    bboxGeometry(topology.objects[key]);
   }
 
   return [x0, y0, x1, y1];

--- a/src/feature.js
+++ b/src/feature.js
@@ -18,31 +18,31 @@ export function feature(topology, o) {
 }
 
 export function object(topology, o) {
-  var transformPoint = transform(topology),
+  var transformPoint = transform(topology.transform),
       arcs = topology.arcs;
 
   function arc(i, points) {
     if (points.length) points.pop();
     for (var a = arcs[i < 0 ? ~i : i], k = 0, n = a.length; k < n; ++k) {
-      points.push(transformPoint(a[k].slice(), k));
+      points.push(transformPoint(a[k], k));
     }
     if (i < 0) reverse(points, n);
   }
 
   function point(p) {
-    return transformPoint(p.slice());
+    return transformPoint(p);
   }
 
   function line(arcs) {
     var points = [];
     for (var i = 0, n = arcs.length; i < n; ++i) arc(arcs[i], points);
-    if (points.length < 2) points.push(points[0].slice());
+    if (points.length < 2) points.push([points[0][0], points[0][1]]); // This should never happen per the specification.
     return points;
   }
 
   function ring(arcs) {
     var points = line(arcs);
-    while (points.length < 4) points.push(points[0].slice());
+    while (points.length < 4) points.push([points[0][0], points[0][1]]); // This may happen if an arc has only two points.
     return points;
   }
 

--- a/src/feature.js
+++ b/src/feature.js
@@ -36,13 +36,13 @@ export function object(topology, o) {
   function line(arcs) {
     var points = [];
     for (var i = 0, n = arcs.length; i < n; ++i) arc(arcs[i], points);
-    if (points.length < 2) points.push([points[0][0], points[0][1]]); // This should never happen per the specification.
+    if (points.length < 2) points.push(points[0]); // This should never happen per the specification.
     return points;
   }
 
   function ring(arcs) {
     var points = line(arcs);
-    while (points.length < 4) points.push([points[0][0], points[0][1]]); // This may happen if an arc has only two points.
+    while (points.length < 4) points.push(points[0]); // This may happen if an arc has only two points.
     return points;
   }
 

--- a/src/quantize.js
+++ b/src/quantize.js
@@ -17,13 +17,18 @@ export default function(topology, n) {
     return tp(point);
   }
 
-  function quantizeGeometry(geometry) {
-    switch (geometry.type) {
-      case "GeometryCollection": return {type: "GeometryCollection", geometries: geometry.geometries.map(quantizeGeometry)}; // TODO id, bbox, features
-      case "Point": return {type: "Point", coordinates: quantizePoint(geometry.coordinates)}; // TODO id, bbox, features
-      case "MultiPoint": return {type: "MultiPoint", coordinates: geometry.coordinates.map(quantizePoint)}; // TODO id, bbox, features
-      default: return geometry;
+  function quantizeGeometry(input) {
+    var output;
+    switch (input.type) {
+      case "GeometryCollection": output = {type: "GeometryCollection", geometries: input.geometries.map(quantizeGeometry)}; break;
+      case "Point": output = {type: "Point", coordinates: quantizePoint(input.coordinates)}; break;
+      case "MultiPoint": output = {type: "MultiPoint", coordinates: input.coordinates.map(quantizePoint)}; break;
+      default: return input;
     }
+    if (input.id != null) output.id = input.id;
+    if (input.bbox != null) output.bbox = input.bbox;
+    if (input.properties != null) output.properties = input.properties;
+    return output;
   }
 
   function quantizeArc(input) {

--- a/src/quantize.js
+++ b/src/quantize.js
@@ -26,10 +26,11 @@ export default function(topology, n) {
     }
   }
 
-  function quantizeArc(input/*, m*/) {
+  function quantizeArc(input) {
     var i = 0, j = 1, n = input.length, p, output = new Array(n); // pessimistic
     output[0] = tp(input[0], 0);
     while (++i < n) if ((p = tp(input[i], i))[0] || p[1]) output[j++] = p; // non-coincident points
+    if (j === 1) output[j++] = [0, 0]; // an arc must have at least two points
     output.length = j;
     return output;
   }

--- a/src/quantize.js
+++ b/src/quantize.js
@@ -1,64 +1,46 @@
 import bbox from "./bbox";
+import untransform from "./untransform";
 
 export default function(topology, n) {
   if (!((n = Math.floor(n)) >= 2)) throw new Error("n must be ≥2");
   if (topology.transform) throw new Error("already quantized");
-  var bb = bbox(topology), name,
-      dx = bb[0], kx = (bb[2] - dx) / (n - 1) || 1,
-      dy = bb[1], ky = (bb[3] - dy) / (n - 1) || 1;
+  var bb = topology.bbox || bbox(topology), key,
+      x0 = bb[0], y0 = bb[1], x1 = bb[2], y1 = bb[3],
+      kx = x1 - x0 ? (x1 - x0) / (n - 1) : 1,
+      ky = y1 - y0 ? (y1 - y0) / (n - 1) : 1,
+      tf = {scale: [kx, ky], translate: [x0, y0]},
+      tp = untransform(tf),
+      inputs = topology.objects,
+      outputs = {};
 
-  function quantizePoint(p) {
-    p[0] = Math.round((p[0] - dx) / kx);
-    p[1] = Math.round((p[1] - dy) / ky);
+  function quantizePoint(point) {
+    return tp(point);
   }
 
-  function quantizeGeometry(o) {
-    switch (o.type) {
-      case "GeometryCollection": o.geometries.forEach(quantizeGeometry); break;
-      case "Point": quantizePoint(o.coordinates); break;
-      case "MultiPoint": o.coordinates.forEach(quantizePoint); break;
+  function quantizeGeometry(geometry) {
+    switch (geometry.type) {
+      case "GeometryCollection": return {type: "GeometryCollection", geometries: geometry.geometries.map(quantizeGeometry)}; // TODO id, bbox, features
+      case "Point": return {type: "Point", coordinates: quantizePoint(geometry.coordinates)}; // TODO id, bbox, features
+      case "MultiPoint": return {type: "MultiPoint", coordinates: geometry.coordinates.map(quantizePoint)}; // TODO id, bbox, features
+      default: return geometry;
     }
   }
 
-  topology.arcs.forEach(function(arc) {
-    var i = 1,
-        j = 1,
-        n = arc.length,
-        pi = arc[0],
-        x0 = pi[0] = Math.round((pi[0] - dx) / kx),
-        y0 = pi[1] = Math.round((pi[1] - dy) / ky),
-        pj,
-        x1,
-        y1;
-
-    for (; i < n; ++i) {
-      pi = arc[i];
-      x1 = Math.round((pi[0] - dx) / kx);
-      y1 = Math.round((pi[1] - dy) / ky);
-      if (x1 !== x0 || y1 !== y0) {
-        pj = arc[j++];
-        pj[0] = x1 - x0, x0 = x1;
-        pj[1] = y1 - y0, y0 = y1;
-      }
-    }
-
-    if (j < 2) {
-      pj = arc[j++];
-      pj[0] = 0;
-      pj[1] = 0;
-    }
-
-    arc.length = j;
-  });
-
-  for (name in topology.objects) {
-    quantizeGeometry(topology.objects[name]);
+  function quantizeArc(input/*, m*/) {
+    var i = 0, j = 1, n = input.length, p, output = new Array(n); // pessimistic
+    output[0] = tp(input[0], 0);
+    while (++i < n) if ((p = tp(input[i], i))[0] || p[1]) output[j++] = p; // non-coincident points
+    output.length = j;
+    return output;
   }
 
-  topology.transform = {
-    scale: [kx, ky],
-    translate: [dx, dy]
+  for (key in inputs) outputs[key] = quantizeGeometry(inputs[key]);
+
+  return {
+    type: "Topology",
+    bbox: bb,
+    transform: tf,
+    objects: outputs,
+    arcs: topology.arcs.map(quantizeArc)
   };
-
-  return topology;
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -8,8 +8,12 @@ export default function(transform) {
       ky = transform.scale[1],
       dx = transform.translate[0],
       dy = transform.translate[1];
-  return function(point, i) {
+  return function(input, i) {
     if (!i) x0 = y0 = 0;
-    return [(x0 += point[0]) * kx + dx, (y0 += point[1]) * ky + dy];
+    var j = 2, n = input.length, output = new Array(n);
+    output[0] = (x0 += input[0]) * kx + dx;
+    output[1] = (y0 += input[1]) * ky + dy;
+    while (j < n) output[j] = input[j], ++j;
+    return output;
   };
 }

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,9 +1,8 @@
 import identity from "./identity";
 
-export default function(topology) {
-  if ((transform = topology.transform) == null) return identity;
-  var transform,
-      x0,
+export default function(transform) {
+  if (transform == null) return identity;
+  var x0,
       y0,
       kx = transform.scale[0],
       ky = transform.scale[1],
@@ -11,8 +10,6 @@ export default function(topology) {
       dy = transform.translate[1];
   return function(point, i) {
     if (!i) x0 = y0 = 0;
-    point[0] = (x0 += point[0]) * kx + dx;
-    point[1] = (y0 += point[1]) * ky + dy;
-    return point;
+    return [(x0 += point[0]) * kx + dx, (y0 += point[1]) * ky + dy];
   };
 }

--- a/src/untransform.js
+++ b/src/untransform.js
@@ -8,14 +8,16 @@ export default function(transform) {
       ky = transform.scale[1],
       dx = transform.translate[0],
       dy = transform.translate[1];
-  return function(point, i) {
+  return function(input, i) {
     if (!i) x0 = y0 = 0;
-    var x1 = Math.round((point[0] - dx) / kx),
-        y1 = Math.round((point[1] - dy) / ky),
-        x = x1 - x0,
-        y = y1 - y0;
-    x0 = x1;
-    y0 = y1;
-    return [x, y];
+    var j = 2,
+        n = input.length,
+        output = new Array(n),
+        x1 = Math.round((input[0] - dx) / kx),
+        y1 = Math.round((input[1] - dy) / ky);
+    output[0] = x1 - x0, x0 = x1;
+    output[1] = y1 - y0, y0 = y1;
+    while (j < n) output[j] = input[j], ++j;
+    return output;
   };
 }

--- a/src/untransform.js
+++ b/src/untransform.js
@@ -1,9 +1,8 @@
 import identity from "./identity";
 
-export default function(topology) {
-  if ((transform = topology.transform) == null) return identity;
-  var transform,
-      x0,
+export default function(transform) {
+  if (transform == null) return identity;
+  var x0,
       y0,
       kx = transform.scale[0],
       ky = transform.scale[1],
@@ -12,9 +11,11 @@ export default function(topology) {
   return function(point, i) {
     if (!i) x0 = y0 = 0;
     var x1 = Math.round((point[0] - dx) / kx),
-        y1 = Math.round((point[1] - dy) / ky);
-    point[0] = x1 - x0, x0 = x1;
-    point[1] = y1 - y0, y0 = y1;
-    return point;
+        y1 = Math.round((point[1] - dy) / ky),
+        x = x1 - x0,
+        y = y1 - y0;
+    x0 = x1;
+    y0 = y1;
+    return [x, y];
   };
 }

--- a/test/bbox-test.js
+++ b/test/bbox-test.js
@@ -2,38 +2,32 @@ var fs = require("fs"),
     tape = require("tape"),
     topojson = require("../");
 
-tape("topojson.bbox(topology) returns the existing bbox, if any", function(test) {
+tape("topojson.bbox(topology) ignores the existing bbox, if any", function(test) {
   var bbox = [1, 2, 3, 4];
-  test.equal(topojson.bbox({type: "Topology", bbox: bbox, objects: {}, arcs: []}), bbox);
+  test.deepEqual(topojson.bbox({type: "Topology", bbox: bbox, objects: {}, arcs: []}), [Infinity, Infinity, -Infinity, -Infinity]);
   test.end();
 });
 
-tape("topojson.bbox(topology) computes and assigns the bbox for a quantized topology, if missing", function(test) {
+tape("topojson.bbox(topology) computes the bbox for a quantized topology, if missing", function(test) {
   var topology = JSON.parse(fs.readFileSync("test/topojson/polygon-q1e4.json"));
-  delete topology.bbox;
-  test.equal(topojson.bbox(topology), topology.bbox);
-  test.deepEqual(topology.bbox, [0, 0, 10, 10]);
-  test.end();
-});
-
-tape("topojson.bbox(topology) computes and assigns the bbox for a non-quantized topology, if missing", function(test) {
-  var topology = JSON.parse(fs.readFileSync("test/topojson/polygon.json"));
-  delete topology.bbox;
-  test.equal(topojson.bbox(topology), topology.bbox);
-  test.deepEqual(topology.bbox, [0, 0, 10, 10]);
-  test.end();
-});
-
-tape("topojson.bbox(topology) computes and assigns considers points", function(test) {
-  var topology = JSON.parse(fs.readFileSync("test/topojson/point.json"));
-  delete topology.bbox;
   test.deepEqual(topojson.bbox(topology), [0, 0, 10, 10]);
   test.end();
 });
 
-tape("topojson.bbox(topology) computes and assigns considers multipoints", function(test) {
+tape("topojson.bbox(topology) computes the bbox for a non-quantized topology, if missing", function(test) {
+  var topology = JSON.parse(fs.readFileSync("test/topojson/polygon.json"));
+  test.deepEqual(topojson.bbox(topology), [0, 0, 10, 10]);
+  test.end();
+});
+
+tape("topojson.bbox(topology) considers points", function(test) {
+  var topology = JSON.parse(fs.readFileSync("test/topojson/point.json"));
+  test.deepEqual(topojson.bbox(topology), [0, 0, 10, 10]);
+  test.end();
+});
+
+tape("topojson.bbox(topology) considers multipoints", function(test) {
   var topology = JSON.parse(fs.readFileSync("test/topojson/points.json"));
-  delete topology.bbox;
   test.deepEqual(topojson.bbox(topology), [0, 0, 10, 10]);
   test.end();
 });

--- a/test/feature-test.js
+++ b/test/feature-test.js
@@ -1,37 +1,37 @@
 var tape = require("tape"),
     topojson = require("../");
 
-tape("feature the geometry type is preserved", function(test) {
+tape("topojson.feature the geometry type is preserved", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[0]]});
   test.equal(topojson.feature(t, t.objects.foo).geometry.type, "Polygon");
   test.end();
 });
 
-tape("feature Point is a valid geometry type", function(test) {
+tape("topojson.feature Point is a valid geometry type", function(test) {
   var t = simpleTopology({type: "Point", coordinates: [0, 0]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "Point", coordinates: [0, 0]}});
   test.end();
 });
 
-tape("feature MultiPoint is a valid geometry type", function(test) {
+tape("topojson.feature MultiPoint is a valid geometry type", function(test) {
   var t = simpleTopology({type: "MultiPoint", coordinates: [[0, 0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "MultiPoint", coordinates: [[0, 0]]}});
   test.end();
 });
 
-tape("feature LineString is a valid geometry type", function(test) {
+tape("topojson.feature LineString is a valid geometry type", function(test) {
   var t = simpleTopology({type: "LineString", arcs: [0]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "LineString", coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]}});
   test.end();
 });
 
-tape("feature MultiLineString is a valid geometry type", function(test) {
+tape("topojson.feature MultiLineString is a valid geometry type", function(test) {
   var t = simpleTopology({type: "LineString", arcs: [0]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "LineString", coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]}});
   test.end();
 });
 
-tape("feature line-strings have at least two coordinates", function(test) {
+tape("topojson.feature line-strings have at least two coordinates", function(test) {
   var t = simpleTopology({type: "LineString", arcs: [3]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "LineString", coordinates: [[1, 1], [1, 1]]}});
   var t = simpleTopology({type: "MultiLineString", arcs: [[3], [4]]});
@@ -39,19 +39,19 @@ tape("feature line-strings have at least two coordinates", function(test) {
   test.end();
 });
 
-tape("feature Polygon is a valid feature type", function(test) {
+tape("topojson.feature Polygon is a valid feature type", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}});
   test.end();
 });
 
-tape("feature MultiPolygon is a valid feature type", function(test) {
+tape("topojson.feature MultiPolygon is a valid feature type", function(test) {
   var t = simpleTopology({type: "MultiPolygon", arcs: [[[0]]]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "MultiPolygon", coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]]}});
   test.end();
 });
 
-tape("feature polygons are closed, with at least four coordinates", function(test) {
+tape("topojson.feature polygons are closed, with at least four coordinates", function(test) {
   var topology = {
     type: "Topology",
     transform: {scale: [1, 1], translate: [0, 0]},
@@ -63,67 +63,67 @@ tape("feature polygons are closed, with at least four coordinates", function(tes
   test.end();
 });
 
-tape("feature top-level geometry collections are mapped to feature collections", function(test) {
+tape("topojson.feature top-level geometry collections are mapped to feature collections", function(test) {
   var t = simpleTopology({type: "GeometryCollection", geometries: [{type: "MultiPolygon", arcs: [[[0]]]}]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "FeatureCollection", features: [{type: "Feature", properties: {}, geometry: {type: "MultiPolygon", coordinates: [[[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]]}}]});
   test.end();
 });
 
-tape("feature geometry collections can be nested", function(test) {
+tape("topojson.feature geometry collections can be nested", function(test) {
   var t = simpleTopology({type: "GeometryCollection", geometries: [{type: "GeometryCollection", geometries: [{type: "Point", coordinates: [0, 0]}]}]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "FeatureCollection", features: [{type: "Feature", properties: {}, geometry: {type: "GeometryCollection", geometries: [{type: "Point", coordinates: [0, 0]}]}}]});
   test.end();
 });
 
-tape("feature top-level geometry collections do not have ids, but second-level geometry collections can", function(test) {
+tape("topojson.feature top-level geometry collections do not have ids, but second-level geometry collections can", function(test) {
   var t = simpleTopology({type: "GeometryCollection", id: "collection", geometries: [{type: "GeometryCollection", id: "feature", geometries: [{type: "Point", id: "geometry", coordinates: [0, 0]}]}]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "FeatureCollection", features: [{type: "Feature", id: "feature", properties: {}, geometry: {type: "GeometryCollection", geometries: [{type: "Point", coordinates: [0, 0]}]}}]});
   test.end();
 });
 
-tape("feature top-level geometry collections do not have properties, but second-level geometry collections can", function(test) {
+tape("topojson.feature top-level geometry collections do not have properties, but second-level geometry collections can", function(test) {
   var t = simpleTopology({type: "GeometryCollection", properties: {collection: true}, geometries: [{type: "GeometryCollection", properties: {feature: true}, geometries: [{type: "Point", properties: {geometry: true}, coordinates: [0, 0]}]}]});
   test.deepEqual(topojson.feature(t, t.objects.foo), {type: "FeatureCollection", features: [{type: "Feature", properties: {feature: true}, geometry: {type: "GeometryCollection", geometries: [{type: "Point", coordinates: [0, 0]}]}}]});
   test.end();
 });
 
-tape("feature the object id is promoted to feature id", function(test) {
+tape("topojson.feature the object id is promoted to feature id", function(test) {
   var t = simpleTopology({id: "foo", type: "Polygon", arcs: [[0]]});
   test.equal(topojson.feature(t, t.objects.foo).id, "foo");
   test.end();
 });
 
-tape("feature any object properties are promoted to feature properties", function(test) {
+tape("topojson.feature any object properties are promoted to feature properties", function(test) {
   var t = simpleTopology({type: "Polygon", properties: {color: "orange", size: 42}, arcs: [[0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo).properties, {color: "orange", size: 42});
   test.end();
 });
 
-tape("feature the object id is optional", function(test) {
+tape("topojson.feature the object id is optional", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[0]]});
   test.equal(topojson.feature(t, t.objects.foo).id, undefined);
   test.end();
 });
 
-tape("feature object properties are created if missing", function(test) {
+tape("topojson.feature object properties are created if missing", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo).properties, {});
   test.end();
 });
 
-tape("feature arcs are converted to coordinates", function(test) {
+tape("topojson.feature arcs are converted to coordinates", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo).geometry.coordinates, [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]);
   test.end();
 });
 
-tape("feature negative arc indexes indicate reversed coordinates", function(test) {
+tape("topojson.feature negative arc indexes indicate reversed coordinates", function(test) {
   var t = simpleTopology({type: "Polygon", arcs: [[~0]]});
   test.deepEqual(topojson.feature(t, t.objects.foo).geometry.coordinates, [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]);
   test.end();
 });
 
-tape("feature when multiple arc indexes are specified, coordinates are stitched together", function(test) {
+tape("topojson.feature when multiple arc indexes are specified, coordinates are stitched together", function(test) {
   var t = simpleTopology({type: "LineString", arcs: [1, 2]});
   test.deepEqual(topojson.feature(t, t.objects.foo).geometry.coordinates, [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]);
   var t = simpleTopology({type: "Polygon", arcs: [[~2, ~1]]});
@@ -131,7 +131,7 @@ tape("feature when multiple arc indexes are specified, coordinates are stitched 
   test.end();
 });
 
-tape("feature unknown geometry types are converted to null geometries", function(test) {
+tape("topojson.feature unknown geometry types are converted to null geometries", function(test) {
   var topology = {
     type: "Topology",
     transform: {scale: [1, 1], translate: [0, 0]},
@@ -145,6 +145,24 @@ tape("feature unknown geometry types are converted to null geometries", function
   test.deepEqual(topojson.feature(topology, topology.objects.foo), {type: "Feature", id: "foo", properties: {}, geometry: null});
   test.deepEqual(topojson.feature(topology, topology.objects.bar), {type: "Feature", properties: {bar: 2}, geometry: null});
   test.deepEqual(topojson.feature(topology, topology.objects.baz), {type: "FeatureCollection", features: [{type: "Feature", id: "unknown", properties: {}, geometry: null}]});
+  test.end();
+});
+
+tape("topojson.feature preserves additional dimensions in Point geometries", function(test) {
+  var t = {type: "Topology", objects: {point: {type: "Point", coordinates: [1, 2, "foo"]}}, arcs: []};
+  test.deepEqual(topojson.feature(t, t.objects.point), {type: "Feature", properties: {}, geometry: {type: "Point", coordinates: [1, 2, "foo"]}});
+  test.end();
+});
+
+tape("topojson.feature preserves additional dimensions in MultiPoint geometries", function(test) {
+  var t = {type: "Topology", objects: {points: {type: "MultiPoint", coordinates: [[1, 2, "foo"]]}}, arcs: []};
+  test.deepEqual(topojson.feature(t, t.objects.points), {type: "Feature", properties: {}, geometry: {type: "MultiPoint", coordinates: [[1, 2, "foo"]]}});
+  test.end();
+});
+
+tape("topojson.feature preserves additional dimensions in LineString geometries", function(test) {
+  var t = {type: "Topology", objects: {line: {type: "LineString", arcs: [0]}}, arcs: [[[1, 2, "foo"], [3, 4, "bar"]]]};
+  test.deepEqual(topojson.feature(t, t.objects.line), {type: "Feature", properties: {}, geometry: {type: "LineString", coordinates: [[1, 2, "foo"], [3, 4, "bar"]]}});
   test.end();
 });
 

--- a/test/quantize-test.js
+++ b/test/quantize-test.js
@@ -26,10 +26,11 @@ tape("topojson.quantize(topology, n) throws an error if the topology is already 
   test.end();
 });
 
-tape("topojson.quantize(topology, n) assigns a bounding box if it is missing", function(test) {
-  var topology = JSON.parse(fs.readFileSync("test/topojson/polygon.json"));
-  delete topology.bbox;
-  test.deepEqual(topojson.quantize(topology, 1e4), JSON.parse(fs.readFileSync("test/topojson/polygon-q1e4.json")));
-  test.deepEqual(topology.bbox, [0, 0, 10, 10]);
+tape("topojson.quantize(topology, n) returns a new topology with a bounding box", function(test) {
+  var before = JSON.parse(fs.readFileSync("test/topojson/polygon.json")),
+      after = (before.bbox = null, topojson.quantize(before, 1e4));
+  test.deepEqual(after, JSON.parse(fs.readFileSync("test/topojson/polygon-q1e4.json")));
+  test.deepEqual(after.bbox, [0, 0, 10, 10]);
+  test.equal(before.bbox, null);
   test.end();
 });

--- a/test/quantize-test.js
+++ b/test/quantize-test.js
@@ -13,6 +13,11 @@ tape("topojson.quantize(topology, n) ensures that each arc has at least two poin
   test.end();
 });
 
+tape("topojson.quantize(topology, n) preserves the id, bbox and properties of input objects", function(test) {
+  test.deepEqual(topojson.quantize(JSON.parse(fs.readFileSync("test/topojson/properties.json")), 1e4), JSON.parse(fs.readFileSync("test/topojson/properties-q1e4.json")));
+  test.end();
+});
+
 tape("topojson.quantize(topology, n) throws an error if n is not at least two", function(test) {
   var topology = JSON.parse(fs.readFileSync("test/topojson/polygon.json"));
   test.throws(function() { topojson.quantize(topology, 0); }, /n must be ≥2/);

--- a/test/quantize-test.js
+++ b/test/quantize-test.js
@@ -8,6 +8,11 @@ tape("topojson.quantize(topology, n) quantizes the input topology", function(tes
   test.end();
 });
 
+tape("topojson.quantize(topology, n) ensures that each arc has at least two points", function(test) {
+  test.deepEqual(topojson.quantize(JSON.parse(fs.readFileSync("test/topojson/empty.json")), 1e4), JSON.parse(fs.readFileSync("test/topojson/empty-q1e4.json")));
+  test.end();
+});
+
 tape("topojson.quantize(topology, n) throws an error if n is not at least two", function(test) {
   var topology = JSON.parse(fs.readFileSync("test/topojson/polygon.json"));
   test.throws(function() { topojson.quantize(topology, 0); }, /n must be ≥2/);

--- a/test/topojson/empty-q1e4.json
+++ b/test/topojson/empty-q1e4.json
@@ -1,0 +1,23 @@
+{
+  "type": "Topology",
+  "bbox": [0, 0, 10, 10],
+  "transform": {
+    "scale": [0.001000100010001, 0.001000100010001],
+    "translate": [0, 0]
+  },
+  "objects": {
+    "polygon": {
+      "type": "Polygon",
+      "arcs": [
+        [0]
+      ]
+    },
+    "line": {
+      "type": "LineString",
+      "arcs": [0]
+    }
+  },
+  "arcs": [
+    [[1000, 2000], [0, 0]]
+  ]
+}

--- a/test/topojson/empty.json
+++ b/test/topojson/empty.json
@@ -1,0 +1,19 @@
+{
+  "type": "Topology",
+  "bbox": [0, 0, 10, 10],
+  "objects": {
+    "polygon": {
+      "type": "Polygon",
+      "arcs": [
+        [0]
+      ]
+    },
+    "line": {
+      "type": "LineString",
+      "arcs": [0]
+    }
+  },
+  "arcs": [
+    [[1, 2], [1, 2], [1, 2], [1, 2], [1, 2], [1, 2]]
+  ]
+}

--- a/test/topojson/properties-q1e4.json
+++ b/test/topojson/properties-q1e4.json
@@ -1,0 +1,57 @@
+{
+  "type": "Topology",
+  "bbox": [0, 0, 10, 10],
+  "transform": {
+    "scale": [0.001000100010001, 0.001000100010001],
+    "translate": [0, 0]
+  },
+  "objects": {
+    "point": {
+      "id": "pointy",
+      "bbox": [1, 2, 1, 2],
+      "properties": {
+        "name": "Point E. Daht"
+      },
+      "type": "Point",
+      "coordinates": [1000, 2000]
+    },
+    "points": {
+      "id": "pointies",
+      "bbox": [1, 2, 3, 4],
+      "properties": {
+        "name": "Sir Points-a-Lot"
+      },
+      "type": "MultiPoint",
+      "coordinates": [[1000, 2000], [3000, 4000]]
+    },
+    "collection": {
+      "id": "collection",
+      "bbox": [1, 2, 1, 2],
+      "properties": {
+        "name": "Collection"
+      },
+      "type": "GeometryCollection",
+      "geometries": [
+        {
+          "type": "Point",
+          "id": "collection-point",
+          "coordinates": [1000, 2000]
+        }
+      ]
+    },
+    "polygon": {
+      "id": "polly",
+      "bbox": [0, 0, 10, 10],
+      "properties": {
+        "name": "Polly Gan"
+      },
+      "type": "Polygon",
+      "arcs": [
+        [0]
+      ]
+    }
+  },
+  "arcs": [
+    [[0, 0], [0, 9999], [9999, 0], [0, -9999], [-9999, 0]]
+  ]
+}

--- a/test/topojson/properties.json
+++ b/test/topojson/properties.json
@@ -1,0 +1,53 @@
+{
+  "type": "Topology",
+  "bbox": [0, 0, 10, 10],
+  "objects": {
+    "point": {
+      "id": "pointy",
+      "bbox": [1, 2, 1, 2],
+      "properties": {
+        "name": "Point E. Daht"
+      },
+      "type": "Point",
+      "coordinates": [1, 2]
+    },
+    "points": {
+      "id": "pointies",
+      "bbox": [1, 2, 3, 4],
+      "properties": {
+        "name": "Sir Points-a-Lot"
+      },
+      "type": "MultiPoint",
+      "coordinates": [[1, 2], [3, 4]]
+    },
+    "collection": {
+      "id": "collection",
+      "bbox": [1, 2, 1, 2],
+      "properties": {
+        "name": "Collection"
+      },
+      "type": "GeometryCollection",
+      "geometries": [
+        {
+          "type": "Point",
+          "id": "collection-point",
+          "coordinates": [1, 2]
+        }
+      ]
+    },
+    "polygon": {
+      "id": "polly",
+      "bbox": [0, 0, 10, 10],
+      "properties": {
+        "name": "Polly Gan"
+      },
+      "type": "Polygon",
+      "arcs": [
+        [0]
+      ]
+    }
+  },
+  "arcs": [
+    [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]
+  ]
+}

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -22,6 +22,14 @@ tape("transform(point) returns a new point", function(test) {
   test.end();
 });
 
+tape("transform(point) preserves extra dimensions", function(test) {
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
+  test.deepEqual(transform([6, 7, 42]), [16, 26, 42]);
+  test.deepEqual(transform([6, 7, "foo"]), [16, 26, "foo"]);
+  test.deepEqual(transform([6, 7, "foo", 42]), [16, 26, "foo", 42]);
+  test.end();
+});
+
 tape("transform(point) transforms individual points", function(test) {
   var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(transform([1, 2]), [6, 11]);

--- a/test/transform-test.js
+++ b/test/transform-test.js
@@ -1,33 +1,29 @@
 var tape = require("tape"),
     topojson = require("../");
 
-tape("topojson.transform(topology) returns the identity function if topology.transform is undefined", function(test) {
-  var topology = {type: "Topology", objects: {}, arcs: []},
-      transform = topojson.transform(topology),
+tape("topojson.transform(topology) returns the identity function if transform is undefined", function(test) {
+  var transform = topojson.transform(null),
       point;
   test.equal(transform(point = {}), point);
   test.end();
 });
 
-tape("topojson.transform(topology) returns a point-transform function if topology.transform is defined", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      transform = topojson.transform(topology);
+tape("topojson.transform(topology) returns a point-transform function if transform is defined", function(test) {
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(transform([6, 7]), [16, 26]);
   test.end();
 });
 
-tape("transform(point) returns the input point, modifying it in-place", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      transform = topojson.transform(topology),
+tape("transform(point) returns a new point", function(test) {
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]}),
       point = [6, 7];
-  test.equal(transform(point), point);
-  test.deepEqual(point, [16, 26]);
+  test.deepEqual(transform(point), [16, 26]);
+  test.deepEqual(point, [6, 7]);
   test.end();
 });
 
 tape("transform(point) transforms individual points", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      transform = topojson.transform(topology);
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(transform([1, 2]), [6, 11]);
   test.deepEqual(transform([3, 4]), [10, 17]);
   test.deepEqual(transform([5, 6]), [14, 23]);
@@ -35,8 +31,7 @@ tape("transform(point) transforms individual points", function(test) {
 });
 
 tape("transform(point, index) transforms delta-encoded arcs", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      transform = topojson.transform(topology);
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(transform([1, 2], 0), [6, 11]);
   test.deepEqual(transform([3, 4], 1), [12, 23]);
   test.deepEqual(transform([5, 6], 2), [22, 41]);
@@ -47,8 +42,7 @@ tape("transform(point, index) transforms delta-encoded arcs", function(test) {
 });
 
 tape("transform(point, index) transforms multiple delta-encoded arcs", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      transform = topojson.transform(topology);
+  var transform = topojson.transform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(transform([1, 2], 0), [6, 11]);
   test.deepEqual(transform([3, 4], 1), [12, 23]);
   test.deepEqual(transform([5, 6], 2), [22, 41]);

--- a/test/untransform-test.js
+++ b/test/untransform-test.js
@@ -22,6 +22,14 @@ tape("untransform(point) returns a new point", function(test) {
   test.end();
 });
 
+tape("untransform(point) preserves extra dimensions", function(test) {
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
+  test.deepEqual(untransform([16, 26, 42]), [6, 7, 42]);
+  test.deepEqual(untransform([16, 26, "foo"]), [6, 7, "foo"]);
+  test.deepEqual(untransform([16, 26, "foo", 42]), [6, 7, "foo", 42]);
+  test.end();
+});
+
 tape("untransform(point) untransforms individual points", function(test) {
   var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(untransform([6, 11]), [1, 2]);

--- a/test/untransform-test.js
+++ b/test/untransform-test.js
@@ -1,33 +1,29 @@
 var tape = require("tape"),
     topojson = require("../");
 
-tape("topojson.untransform(topology) returns the identity function if topology.transform is undefined", function(test) {
-  var topology = {type: "Topology", objects: {}, arcs: []},
-      untransform = topojson.untransform(topology),
+tape("topojson.untransform(topology) returns the identity function if transform is undefined", function(test) {
+  var untransform = topojson.untransform(null),
       point;
   test.equal(untransform(point = {}), point);
   test.end();
 });
 
-tape("topojson.untransform(topology) returns a point-transform function if topology.transform is defined", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      untransform = topojson.untransform(topology);
+tape("topojson.untransform(topology) returns a point-transform function if transform is defined", function(test) {
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(untransform([16, 26]), [6, 7]);
   test.end();
 });
 
-tape("untransform(point) returns the input point, modifying it in-place", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      untransform = topojson.untransform(topology),
+tape("untransform(point) returns a new point", function(test) {
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]}),
       point = [16, 26];
-  test.equal(untransform(point), point);
-  test.deepEqual(point, [6, 7]);
+  test.deepEqual(untransform(point), [6, 7]);
+  test.deepEqual(point, [16, 26]);
   test.end();
 });
 
 tape("untransform(point) untransforms individual points", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      untransform = topojson.untransform(topology);
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(untransform([6, 11]), [1, 2]);
   test.deepEqual(untransform([10, 17]), [3, 4]);
   test.deepEqual(untransform([14, 23]), [5, 6]);
@@ -35,8 +31,7 @@ tape("untransform(point) untransforms individual points", function(test) {
 });
 
 tape("untransform(point, index) untransforms delta-encoded arcs", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      untransform = topojson.untransform(topology);
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(untransform([6, 11], 0), [1, 2]);
   test.deepEqual(untransform([12, 23], 1), [3, 4]);
   test.deepEqual(untransform([22, 41], 2), [5, 6]);
@@ -47,8 +42,7 @@ tape("untransform(point, index) untransforms delta-encoded arcs", function(test)
 });
 
 tape("untransform(point, index) untransforms multiple delta-encoded arcs", function(test) {
-  var topology = {type: "Topology", transform: {scale: [2, 3], translate: [4, 5]}, objects: {}, arcs: []},
-      untransform = topojson.untransform(topology);
+  var untransform = topojson.untransform({scale: [2, 3], translate: [4, 5]});
   test.deepEqual(untransform([6, 11], 0), [1, 2]);
   test.deepEqual(untransform([12, 23], 1), [3, 4]);
   test.deepEqual(untransform([22, 41], 2), [5, 6]);


### PR DESCRIPTION
Fixes #10.

This also changes [topojson.quantize](https://github.com/topojson/topojson-client/blob/non-destructive/README.md#quantize) so that you can pass in an arbitrary transform, rather than always generating a new transform based on a quantization parameter. This allows you to re-apply an existing transform to a previously-quantized topology, or to give multiple topologies the same transform.

**This will be a major version change, released as 3.0.**