### PR TITLE
Fix MultiLineString test in feature-test.js

### DIFF
--- a/test/feature-test.js
+++ b/test/feature-test.js
@@ -26,8 +26,8 @@ tape("topojson.feature LineString is a valid geometry type", function(test) {
 });
 
 tape("topojson.feature MultiLineString is a valid geometry type", function(test) {
-  var t = simpleTopology({type: "LineString", arcs: [0]});
-  test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "LineString", coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]}});
+  var t = simpleTopology({type: "MultiLineString", arcs: [[0]]});
+  test.deepEqual(topojson.feature(t, t.objects.foo), {type: "Feature", properties: {}, geometry: {type: "MultiLineString", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]}});
   test.end();
 });
 


### PR DESCRIPTION
The _MultiLineString_ test is done on a _LineString_ geometry,
which is the same code as for the _LineString_ test...
So, I changed the topology object to _MultiLineString_.
Test still pass.