### PR TITLE
Add possibility to filter by arc's index in mesh function.

### DIFF
--- a/src/mesh.js
+++ b/src/mesh.js
@@ -47,7 +47,7 @@ function extractArcs(topology, object, filter) {
 
   geomsByArc.forEach(filter == null
       ? function(geoms) { arcs.push(geoms[0].i); }
-      : function(geoms) { if (filter(geoms[0].g, geoms[geoms.length - 1].g)) arcs.push(geoms[0].i); });
+      : function(geoms) { if (filter(geoms[0].g, geoms[geoms.length - 1].g, geoms[0].i, geoms[geoms.length - 1].i)) arcs.push(geoms[0].i); });
 
   return arcs;
 }

--- a/test/mesh-test.js
+++ b/test/mesh-test.js
@@ -63,3 +63,33 @@ tape("mesh does not stitch together two disconnected line strings", function(tes
   });
   test.end();
 });
+
+tape("mesh allows to filter by arc's index", function(test) {
+  var topology = {
+    "type": "Topology",
+    "objects": {
+      "collection": {
+        "type": "GeometryCollection",
+        "geometries": [
+          {"type": "LineString", "arcs": [0]},
+          {"type": "LineString", "arcs": [1]}
+        ]
+      }
+    },
+    "arcs":[
+      [[2, 0], [3, 0]],
+      [[0, 0], [1, 0]]
+    ]
+  };
+  test.inDelta(topojson.mesh(topology, topology.objects.collection, function(objA, objB, arcA, arcB) {
+    if (arcA === 0) {
+      return false;
+    } {
+      return true;
+    }
+  }), {
+    type: "MultiLineString",
+    coordinates: [[[0, 0], [1, 0]]]
+  });
+  test.end();
+});


### PR DESCRIPTION
Hello, in my project, I'd like to have the possibility to check also arc's index inside my filter method. I've analyzed mesh function and I've just added two parameters into filter function. I'd be glad if you could merge this and release to npm. Without that, I cannot proceed with my project.