### PR TITLE
Allow topojson.mesh to take a name

### DIFF
--- a/src/mesh.js
+++ b/src/mesh.js
@@ -6,6 +6,7 @@ export default function(topology) {
 }
 
 export function meshArcs(topology, object, filter) {
+  if (typeof object === "string") object = topology.objects[object];
   var arcs, i, n;
   if (arguments.length > 1) arcs = extractArcs(topology, object, filter);
   else for (i = 0, arcs = new Array(n = topology.arcs.length); i < n; ++i) arcs[i] = i;


### PR DESCRIPTION
Align `topojson.mesh` on `topojson.feature` by allowing `object` to be a string (treated as `topology.objects[object]`)